### PR TITLE
Update hubble.rb to fix missing version info

### DIFF
--- a/Formula/h/hubble.rb
+++ b/Formula/h/hubble.rb
@@ -27,7 +27,7 @@ class Hubble < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X github.com/cilium/hubble/pkg.Version=#{version}"
+    ldflags = "-s -w -X github.com/cilium/cilium/hubble/pkg.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:)
 
     generate_completions_from_executable(bin/"hubble", "completion")


### PR DESCRIPTION
The pkg directory under the github.com/cilium/hubble was moved to github.com/cilium/cilium/hubble and this meant that the formula injecting the version using the linker -X flag was not the right location anymore.

Symptom was there was a double space where the version should have been reported by the `hubble version` command.

```
$ hubble version
hubble  compiled with go1.25.1 on darwin/arm64
```

